### PR TITLE
Initial OSR Microsite and Repo Information Architecture

### DIFF
--- a/docs/community-ecosystem/resources.md
+++ b/docs/community-ecosystem/resources.md
@@ -1,0 +1,7 @@
+---
+id: resources
+title: What is a Community Ecosystem?
+sidebar_label: What is a Community Ecosystem?
+---
+
+Placeholder

--- a/docs/corporate-alignment/resources.md
+++ b/docs/corporate-alignment/resources.md
@@ -1,0 +1,7 @@
+---
+id: resources
+title: How to align your firm
+sidebar_label: Aligning Your Firm
+---
+
+Placeholder

--- a/docs/culture/resources.md
+++ b/docs/culture/resources.md
@@ -1,0 +1,7 @@
+---
+id: resources
+title: How to create a positive community
+sidebar_label: Creating Possitive Communities
+---
+
+Placeholder

--- a/docs/goals-objectives/resources.md
+++ b/docs/goals-objectives/resources.md
@@ -1,0 +1,7 @@
+---
+id: resources
+title: Defining Corporate Objectives
+sidebar_label: Defining Corporate Objectives
+---
+
+Placeholder

--- a/docs/operations/resources.md
+++ b/docs/operations/resources.md
@@ -1,0 +1,7 @@
+---
+id: resources
+title: The Role of Operations
+sidebar_label: The Role of Operations
+---
+
+Placeholder

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -5,7 +5,7 @@
       "resources",
       "about"
     ],
-    "Materials": [
+    "OSR SIG Materials": [
       {
         "type": "subcategory",
         "label": "Goals and Objectives",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,5 +1,46 @@
 {
   "docs": {
-    "General": ["meetings", "resources", "about"]
+    "General": [
+      "meetings",
+      "resources",
+      "about"
+    ],
+    "Materials": [
+      {
+        "type": "subcategory",
+        "label": "Goals and Objectives",
+        "ids": [
+          "goals-objectives/resources"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Corportate Alignment",
+        "ids": [
+          "corporate-alignment/resources"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Community & Ecosystem",
+        "ids": [
+          "community-ecosystem/resources"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Operations",
+        "ids": [
+          "operations/resources"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Culture",
+        "ids": [
+          "culture/resources"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description
This PR adds initial documentation placeholders to the Open Source Readiness repo and microsite to enable SIG lead and wider OSR community engagement and contribution.

This PR follows the categorisation pattern as discussed in https://github.com/finos/open-source-readiness/discussions/23#discussioncomment-2280316

## Placeholder Materials

### Microsite Categories

`website/sidebars.json` describes the sections added to the `osr` microsite and `markdown` placeholders added to the `osr` repo. The additions to `website/sidebars.json` are listed below.

```
{
  "docs": {
    "Materials": [
      {
        "type": "subcategory",
        "label": "Goals and Objectives",
        "ids": [
          "goals-objectives/resources"
        ]
      },
      {
        "type": "subcategory",
        "label": "Corportate Alignment",
        "ids": [
          "corporate-alignment/resources"
        ]
      },
      {
        "type": "subcategory",
        "label": "Community & Ecosystem",
        "ids": [
          "community-ecosystem/resources"
        ]
      },
      {
        "type": "subcategory",
        "label": "Operations",
        "ids": [
          "operations/resources"
        ]
      },
      {
        "type": "subcategory",
        "label": "Culture",
        "ids": [
          "culture/resources"
        ]
      }
    ]
  }
}
```

### Repo Placeholder Markdown

The following `markdown` placeholders have been added to the `osr` repo for contributors to follow as work is contributed.

- `docs/community-ecosystem/resources.md`
- `docs/corporate-alignment/resources.md`
- `docs/culture/resources.md`
- `docs/goals-objectives/resources.md`
- `docs/operations/resources.md`