### PR TITLE
Fix `Corporate Alignment` Typo on OSR Microsite

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -15,7 +15,7 @@
       },
       {
         "type": "subcategory",
-        "label": "Corportate Alignment",
+        "label": "Corporate Alignment",
         "ids": [
           "corporate-alignment/resources"
         ]


### PR DESCRIPTION
## Description
This pull request fixes the following typing mistake as communicated in #28 here https://github.com/finos/open-source-readiness/pull/28#discussion_r844018945

### Contributed Change
Within `website/sidebars.json` ... `"label": "Corportate Alignment"` has been changed to `"label": "Corporate Alignment"`.