### PR TITLE
Update OSR Footer Community Links

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -56,13 +56,13 @@ class Footer extends React.Component {
               FINOS Website
             </a>
             <a
-              href="https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/80642059/Community+Handbook"
+              href="https://community.finos.org/"
               target="_blank"
               rel="noreferrer noopener">
-              Community Handbook
+              Community Microsite
             </a>
             <a
-              href="https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530783/Community+Governance"
+              href="https://community.finos.org/docs/governance/intro"
               target="_blank"
               rel="noreferrer noopener">
               Community Governance


### PR DESCRIPTION
## Description
This PR resolves #25 by updating archived links in the OSR microsite footer with updated paths to the `FINOS Community Microsite`.

The links to be updated are the following ...

1. `Community Governance` now links to Community Governance within the `FINOS Community Microsite`.
2. `Community Handbook` now links to the `FINOS Community Microsite` homepage.


## Footer Configuration Changes

```
<a
 href="https://community.finos.org/"
 target="_blank"
 rel="noreferrer noopener">
 Community Microsite
</a>
<a
 href="https://community.finos.org/docs/governance/intro"
 target="_blank"
 rel="noreferrer noopener">
 Community Governance
</a>           
```