### PR TITLE
[DRAFT] Set trailingSlash to false

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,6 +3,7 @@ module.exports={
   "tagline": "OVERCOMING OBSTACLES TO OPEN SOURCE",
   "url": "https://osr.finos.org/",
   "baseUrl": "/",
+  "trailingSlash"; false,
   "organizationName": "FINOS",
   "projectName": "open-source-readiness",
   "scripts": [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,7 +3,7 @@ module.exports={
   "tagline": "OVERCOMING OBSTACLES TO OPEN SOURCE",
   "url": "https://osr.finos.org/",
   "baseUrl": "/",
-  "trailingSlash"; false,
+  "trailingSlash": false,
   "organizationName": "FINOS",
   "projectName": "open-source-readiness",
   "scripts": [


### PR DESCRIPTION
Trying to fix broken links using the trailingSlash option, see https://github.com/finos/open-source-readiness/issues/185

This PR may not be ready to be merged; the preview must be carefully tested:
1. Access https://osr.finos.org/docs/bok/activities/level-3/making-the-case/#worsened-risk-position-1 (set the host to the preview one)
2. Click on first link, `DLP Software` ; open link should be https://osr.finos.org/docs/bok/artifacts/dlp-software/ , instead of https://osr.finos.org/docs/bok/activities/Artifacts/DLP-Software