### PR TITLE
Unaware and Prefer Not To Answer

### DIFF
--- a/docs/Presentations/OpenChain.md
+++ b/docs/Presentations/OpenChain.md
@@ -19,3 +19,4 @@ import ReactPlayer from 'react-player';
 Shane Coughlan (OpenChain, Linux Foundation) to FINOS Members Meeting on May 1st 2024. </Bio>
 
 <ReactPlayer playing controls width="100%" height="400px" url="https://www.finos.org/hubfs/Projects%20%2B%20SIGs/Open%20Source%20Readiness%20OSR/2024-05%20-%20OSR%20Meeting%20Shane%20Coughlan%20Presentation.mp4" />
+

--- a/docs/bok/OSMM/Introduction.md
+++ b/docs/bok/OSMM/Introduction.md
@@ -41,7 +41,7 @@ The OSR SIG are working on a [Maturity Checklist](Checklist) which asks you to m
 
 For each activity you can assign one of the following values (taken from the [CMMI Model](https://en.wikipedia.org/wiki/Capability_Maturity_Model_Integration)):
 
-### 0. Unaware
+### 0. Unaware or Prefer Not To Answer
 
 This is the default.  Leave this value as-is if you are not aware of how your organisation performs this activity.
 

--- a/docs/bok/OSMM/Introduction.md
+++ b/docs/bok/OSMM/Introduction.md
@@ -43,7 +43,7 @@ For each activity you can assign one of the following values (taken from the [CM
 
 ### 0. Unaware or Prefer Not To Answer
 
-This is the default.  Leave this value as-is if you are not aware of how your organisation performs this activity.
+This is the default.  Leave this value as-is if you are not aware of how your organisation performs this activity, or you'd prefer not to give an answer.
 
 ### 1. Initial
 

--- a/website/src/theme/ArticleChecklist/index.js
+++ b/website/src/theme/ArticleChecklist/index.js
@@ -6,11 +6,11 @@ const expDays = 2000;
 
 export const levels = [
 	{
-		name: "Unaware",
-		description: "No awareness of this activity",
+		name: "N/A or Unaware",
+		description: "Prefer not to answer or unaware of firm level",
 		class: styles.unaware,
 		color: "000000",
-		link: "/docs/bok/OSMM/Introduction#0-unaware"
+		link: "/docs/bok/OSMM/Introduction#0-unaware-or-prefer-not-to-answer"
 	},
 	{
 		name: "Initial",

--- a/website/src/theme/ArticleChecklist/styles.module.css
+++ b/website/src/theme/ArticleChecklist/styles.module.css
@@ -102,6 +102,7 @@
 
 .value { 
 	justify-self: center;
+	text-align: center;
 	grid-area: 2 / 2 / 3 / 3;
  }
 


### PR DESCRIPTION
@mcleo-d has requested that there is an option to "prefer not to answer" something in the checklist.

Since for the purposes of reporting and aggregating, this would be the same as the respondent not being aware of the firm's level, I have incorporated this as an alternative meaning for our level 0 setting:

![Screenshot 2024-08-16 at 10 26 28](https://github.com/user-attachments/assets/b037e8ea-5086-44bf-9c81-d49f25fd8c81)

Hopefully this will both allow him to complete the checklist and also avoid making it more complex than it needs to be.  

