### PR TITLE
Innersource test commit

### DIFF
--- a/docs/InnerSource/Introduction.md
+++ b/docs/InnerSource/Introduction.md
@@ -36,7 +36,8 @@ ownership issues that can stall innovation.
 
 <BoxOut image="/img/bok/page-types/involved.png" title="Get Involved" className='boxout2'>
 
-Meetings are open to anyone who would like to participate. Previous Meeting Minutes and Agendas are available on [GitHub](https://github.com/finos/open-source-readiness/issues?q=is%3Aissue++label%3Ameeting). For current meetings, follow the [FINOS Calendar](https://calendar.finos.org).
+Meetings are open to anyone who would like to participate. Previous Meeting Minutes and Agendas are available on [GitHub](https://github.com/finos/InnerSource/issues?q=is%3Aissue++label%3Ameeting)
+    . For current meetings, follow the [FINOS Calendar](https://calendar.finos.org).
 
 ### Subscribe to the Mailing List
 

--- a/docs/InnerSource/Team.md
+++ b/docs/InnerSource/Team.md
@@ -7,6 +7,7 @@ sidebar_position: 1
 | :------------- | :------------------ | :----------------------- |
 | Brittany Istenes | Fannie Mae        | SIG Co-Lead              |
 | Chamindra de Silva  | Citi           | SIG Co-Lead              |
+| Pooi Cheong   | Natwest           .  | SIG Co-Lead              |
 | Rob Moffat    | FINOS  | SIG Secretary            |
 | Peter Smulovics   | Morgan Stanley      | SIG Leadership Committee |
 | Miguel Captiao  | Deutsche bank            | SIG Leadership Committee |


### PR DESCRIPTION
Test commit to OSR in prep for the InnerSource playbook site. This commit adds Pooi as a co-maintainer and updates the link to the meeting issues 