### PR TITLE
Innersource introduction

### DIFF
--- a/docs/InnerSource/Introduction.md
+++ b/docs/InnerSource/Introduction.md
@@ -5,13 +5,13 @@ hide_table_of_contents: true
 
 <img src="/img/bok/page-types/2020_InnerSourceSIG_Horizontal.png" className="page-header-image" />
 
-# Welcome to the InnerSource SIG
+# Welcome to the InnerSource Special Interest Group
 
 <div className="frontPageContent">
 
 <BoxOut image="/img/bok/page-types/what.png" title="What is it?" className='boxout1' link="/docs/InnerSource/Introduction" linkText="Find out More">
 
-The FINOS InnerSource <a href="https://github.com/finos/community/tree/master/governance#special-interest-groups">Special Interest Group</a> is a community of people implementing, or interested in implementing, InnerSource within their financial services organization in order to increase collaboration and remove/deal with excessive ownership issues that can stall innovation.
+The FINOS InnerSource SIG is a community of people implementing, or interested in implementing, InnerSource within their financial services organization in order to increase collaboration and remove/deal with excessive ownership issues that can stall innovation.
 
 It is likely of particular importance to financial services organisations who wish to accelerate their InnerSource practices, share best practices, patterns and anti-patterns and potentially related code in a secure environment in collaboration with others in similar positions.
 InnerSource can help break down silos, encourage internal collaboration and
@@ -33,22 +33,16 @@ ownership issues that can stall innovation.
 
 </BoxOut>
 
-
 <BoxOut image="/img/bok/page-types/involved.png" title="Get Involved" className='boxout2'>
 
-Meetings are open to anyone who would like to participate. Previous Meeting Minutes and Agendas are available on [GitHub](https://github.com/finos/InnerSource/issues?q=is%3Aissue++label%3Ameeting)
-    . For current meetings, follow the [FINOS Calendar](https://calendar.finos.org).
-
-### Subscribe to the Mailing List
-
- - Subscribe to [our mailing list](mailto:innersource+subscribe@finos.org)
-
+The InnerSource SIG is open to anyone interested in learning about, contributing to, or advancing InnerSource practices across the financial services industry.
+### Join the SIG
+- **Register to receive meeting invitations:** [Registration Link](https://zoom-lfx.platform.linuxfoundation.org/meeting/92852768369?password=9ffd3106-34d9-42bc-b530-8c7866386826&invite=true)
+- Meeting schedule: **Weekly on Mondays** at 2:00 PM UK, 3:00 PM CET, 6:30 PM IST, and 9:00 AM ET
+- Upcoming meetings and joining details: [FINOS Calendar](https://calendar.finos.org).
+- **Subscribe to the Mailing List:** [Mailing List](mailto:innersource+subscribe@finos.org)
+- Previous meeting agendas and minutes: [GitHub Link](https://github.com/finos/InnerSource/issues?q=is%3Aissue++label%3Ameeting)
 
 </BoxOut>
 </div>
 
-## InnerSource Resources
-
-Here are some main jumping-off articles tagged with InnerSource.
-
-<BokTagList tag="InnerSource" />

--- a/docs/InnerSource/Introduction.md
+++ b/docs/InnerSource/Introduction.md
@@ -40,7 +40,6 @@ The InnerSource SIG is open to anyone interested in learning about, contributing
 - **Register to receive meeting invitations:** [Registration Link](https://zoom-lfx.platform.linuxfoundation.org/meeting/92852768369?password=9ffd3106-34d9-42bc-b530-8c7866386826&invite=true)
 - Meeting schedule: **Weekly on Mondays** at 2:00 PM UK, 3:00 PM CET, 6:30 PM IST, and 9:00 AM ET
 - Upcoming meetings and joining details: [FINOS Calendar](https://calendar.finos.org).
-- **Subscribe to the Mailing List:** [Mailing List](mailto:innersource+subscribe@finos.org)
 - Previous meeting agendas and minutes: [GitHub Link](https://github.com/finos/InnerSource/issues?q=is%3Aissue++label%3Ameeting)
 
 </BoxOut>


### PR DESCRIPTION
Updates the InnerSource SIG landing page (Introduction.md) to improve clarity and onboarding for new participants.

### Changes
- Removed the **Resources** section, as content is available on a dedicated page.
- Removed a broken hyperlink from the introduction.
- Updated the **Getting Involved** section to include registration for meeting invitations and regular meeting schedule
- Removed the mailing list subscription link, as it is not currently used.